### PR TITLE
somtimes there are more than one font declaration, so that the others…

### DIFF
--- a/src/RtfToHtml.js
+++ b/src/RtfToHtml.js
@@ -294,7 +294,7 @@ export const RtfToHtml = function(options) {
 
     let fontTable = () => {
         for( ; index < rtf.length; index++) {
-            if(rtf[index] === '}') {
+            if(rtf[index] === '}' && rtf[index - 1] === '}') {
                 return;
             }
         }


### PR DESCRIPTION
… are displayed after parsing the rtf.

for example:
```
{\rtf1\ansi\ansicpg1252\deff0\deflang1031{\fonttbl{\f0\fnil\fprq2\fcharset0 Calibri;}{\f1\fswiss\fcharset0 Arial;}{\f2\fnil\fcharset0 MS Shell Dlg;}}
{\colortbl ;\red0\green0\blue0;\red255\green0\blue0;}
\viewkind4\uc1\pard\cf1\f0\fs20 Das ist eine \cf2\b\f1 Testmassnahme \cf1\b0\f0 mit einem \i\f1\fs24 Beispieltext\cf0\i0\f2\fs17\par
}
```

if checking just one brace the parsing stops after the first font declaration. and the output looked like this: 
```html
<p>Arial; MS Shell Dlg;<span style="color:#000000">Das ist eine </span><span style="color:#ff0000">Testmassnahme </span><span style="color:#000000">mit einem Beispieltext</span></p><p></p>
```

so to fix that, I extended the condition for breaking the loop, whenever there is also an previous brace.